### PR TITLE
fix for issue 2

### DIFF
--- a/prealloc.go
+++ b/prealloc.go
@@ -213,7 +213,7 @@ func (v *returnsVisitor) Visit(node ast.Node) ast.Visitor {
 	v.sliceDeclarations = nil
 	v.preallocMsgs = nil
 	v.returnsInsideOfLoop = false
-	var arrayTypes []string = nil
+	var arrayTypes []string
 
 	switch n := node.(type) {
 	case *ast.FuncDecl:
@@ -234,7 +234,9 @@ func (v *returnsVisitor) Visit(node ast.Node) ast.Visitor {
 							}
 
 							if _, ok := tSpec.Type.(*ast.ArrayType); ok {
-								arrayTypes = append(arrayTypes, tSpec.Name.Name)
+								if tSpec.Name != nil {
+									arrayTypes = append(arrayTypes, tSpec.Name.Name)
+								}
 							}
 						}
 					} else if genD.Tok == token.VAR {
@@ -244,11 +246,10 @@ func (v *returnsVisitor) Visit(node ast.Node) ast.Visitor {
 								continue
 							}
 							var isArrType bool
-							switch vSpec.Type.(type) {
+							switch val := vSpec.Type.(type) {
 							case *ast.ArrayType:
 								isArrType = true
 							case *ast.Ident:
-								val, _ := vSpec.Type.(*ast.Ident)
 								isArrType = contains(arrayTypes, val.Name)
 							}
 							if isArrType {

--- a/prealloc.go
+++ b/prealloc.go
@@ -208,14 +208,21 @@ func contains(slice []string, item string) bool {
 	return false
 }
 
+var arrayTypes []string
+
 func (v *returnsVisitor) Visit(node ast.Node) ast.Visitor {
 
 	v.sliceDeclarations = nil
 	v.preallocMsgs = nil
 	v.returnsInsideOfLoop = false
-	var arrayTypes []string
 
 	switch n := node.(type) {
+	case *ast.TypeSpec:
+		if _, ok := n.Type.(*ast.ArrayType); ok {
+			if n.Name != nil {
+				arrayTypes = append(arrayTypes, n.Name.Name)
+			}
+		}
 	case *ast.FuncDecl:
 		if n.Body != nil {
 			for _, stmt := range n.Body.List {

--- a/prealloc.go
+++ b/prealloc.go
@@ -199,13 +199,13 @@ func exists(filename string) bool {
 }
 
 func contains(slice []string, item string) bool {
-	set := make(map[string]struct{}, len(slice))
 	for _, s := range slice {
-		set[s] = struct{}{}
+		if s == item {
+			return true
+		}
 	}
 
-	_, ok := set[item]
-	return ok
+	return false
 }
 
 func (v *returnsVisitor) Visit(node ast.Node) ast.Visitor {
@@ -243,12 +243,15 @@ func (v *returnsVisitor) Visit(node ast.Node) ast.Visitor {
 							if !ok {
 								continue
 							}
-							var ok2 bool
-							/*arrayType*/ _, ok1 := vSpec.Type.(*ast.ArrayType)
-							if val, ok := vSpec.Type.(*ast.Ident); ok {
-								ok2 = contains(arrayTypes, val.Name)
+							var isArrType bool
+							switch vSpec.Type.(type) {
+							case *ast.ArrayType:
+								isArrType = true
+							case *ast.Ident:
+								val, _ := vSpec.Type.(*ast.Ident)
+								isArrType = contains(arrayTypes, val.Name)
 							}
-							if ok1 || ok2 {
+							if isArrType {
 								if vSpec.Names != nil {
 									/*atID, ok := arrayType.Elt.(*ast.Ident)
 									if !ok {


### PR DESCRIPTION
This is a fix for the [issue](https://github.com/alexkohler/prealloc/issues/2)

I have done manual testing to test the code changes and it works as expected.

    type MySlice3 []string
    func main() {
    	type MySlice1 []string
    	type MySlice2 = []string

    	var var1 MySlice1
    	var var2 []string
    	var3 := make([]string, 10, 10)
    	var var4 MySlice2
        var var5 MySlice3
    	for feature := range optionalSet {
    		var1 = append(var1, feature)
    		var2 = append(var2, feature)
    		var3 = append(var3, feature)
    		var4 = append(var4, feature)
    		var5 = append(var5, feature)
    	}
    }

../../bin/test.go:9 Consider preallocating var1
../../bin/test.go:10 Consider preallocating var2
../../bin/test.go:12 Consider preallocating var4
../../bin/test.go:13 Consider preallocating var5