### PR TITLE
Add map preallocation benchmarks

### DIFF
--- a/prealloc_test.go
+++ b/prealloc_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"go/token"
 	"testing"
 
@@ -123,5 +124,36 @@ func BenchmarkSize200PreallocateCopy(b *testing.B) {
 		// Preallocate our initial slice
 		init := make([]int64, len(existing))
 		copy(init, existing)
+	}
+}
+
+func BenchmarkMap(b *testing.B) {
+	benchmarks := []struct {
+		size        int
+		preallocate bool
+	}{
+		{10, false},
+		{10, true},
+		{200, false},
+		{200, true},
+	}
+	var m map[int]int
+	for _, bm := range benchmarks {
+		no := ""
+		if !bm.preallocate {
+			no = "No"
+		}
+		b.Run(fmt.Sprintf("Size%d%sPreallocate", bm.size, no), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if bm.preallocate {
+					m = make(map[int]int, bm.size)
+				} else {
+					m = make(map[int]int)
+				}
+				for j := 0; j < bm.size; j++ {
+					m[j] = j
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Results from system in front of me:
```
BenchmarkMap/Size10NoPreallocate-4  	 1954923	       603.7 ns/op	     484 B/op	       3 allocs/op
BenchmarkMap/Size10Preallocate-4    	 2951250	       393.8 ns/op	     340 B/op	       2 allocs/op
BenchmarkMap/Size200NoPreallocate-4 	   71530	     15337 ns/op	   11270 B/op	      25 allocs/op
BenchmarkMap/Size200Preallocate-4   	  126673	      8216 ns/op	    5719 B/op	       8 allocs/op
```