### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ prealloc is a Go static analysis tool to find slice declarations that could pote
 
 ## Installation
 
-    go get -u github.com/alexkohler/prealloc
+    go install github.com/alexkohler/prealloc@latest
 
 ## Usage
 


### PR DESCRIPTION
`go get` currently modifies the `go.mod` file and that's probably not what you want installing a linter. Use `go install` instead.

https://go.dev/ref/mod