### PR TITLE
Allow no-argument methods in capacity suggestions

### DIFF
--- a/pkg/prealloc.go
+++ b/pkg/prealloc.go
@@ -837,6 +837,11 @@ func hasCall(expr ast.Expr) bool {
 					// allow cheap pure built-in functions
 					return true
 				}
+			case *ast.SelectorExpr:
+				// allow argument-less methods
+				if len(call.Args) == 0 {
+					return true
+				}
 			}
 			found = true
 		}

--- a/testdata/for.go
+++ b/testdata/for.go
@@ -1,5 +1,7 @@
 package test
 
+import "bytes"
+
 func forInfinite() {
 	var x []int
 	for {
@@ -222,6 +224,14 @@ func forDecBackwardsCondition() {
 func forTypeConvert() {
 	var x []uint // want "Consider preallocating x with capacity 5$"
 	for i := uint(0); i < uint(5); i++ {
+		x = append(x, i)
+	}
+}
+
+func forNoArgMethod() {
+	var buf bytes.Buffer
+	var x []int // want "Consider preallocating x with capacity buf\\.Len\\(\\)$"
+	for i := 0; i < buf.Len(); i++ {
 		x = append(x, i)
 	}
 }

--- a/testdata/range.go
+++ b/testdata/range.go
@@ -1,6 +1,9 @@
 package test
 
-import "sort"
+import (
+	"bytes"
+	"sort"
+)
 
 func rangeZero() {
 	var x []int
@@ -178,6 +181,14 @@ func rangeMapFunc() {
 func rangeIntTypeConvert() {
 	var x []uint // want "Consider preallocating x with capacity 5$"
 	for i := range uint(5) {
+		x = append(x, i)
+	}
+}
+
+func rangeIntNoArgMethod() {
+	var buf bytes.Buffer
+	var x []int // want "Consider preallocating x with capacity buf\\.Len\\(\\)$"
+	for i := range buf.Len() {
 		x = append(x, i)
 	}
 }


### PR DESCRIPTION
This linter assumes that function calls (excluding built-ins) could be expensive and excludes them from capacity suggestions. I've noticed that it's quite common to use no-argument (niladic) methods like `.Len()` in for loop bounds, These are almost always cheap wrappers around private fields that are safe to call for preallocation purposes.
This PR relaxes the no-func-call restriction to allow theses.